### PR TITLE
Add exception handling for empty wfm data

### DIFF
--- a/curvequery/_tek_series_mso.py
+++ b/curvequery/_tek_series_mso.py
@@ -197,9 +197,12 @@ class TekSeriesCurveFeat(FeatureBase):
                 instr.write("curv?")
 
                 # Read the waveform data sent by the instrument
-                source_data = instr.read_binary_values(
-                    datatype=datatype, is_big_endian=True, expect_termination=True
-                )
+                try:
+                    source_data = instr.read_binary_values(
+                        datatype=datatype, is_big_endian=True, expect_termination=True)
+                except Exception:
+                    print("Error: No waveform data found. Check waveform on scope.")
+                    continue
 
                 # Normal analog channels must have the vertical scale and offset applied
                 if wave_type is WaveType.ANALOG:


### PR DESCRIPTION
Fixes #21 by adding try-except block on reading the data for 4/5/6 series scopes.

Please test on your own scopes. @zkoppert - I've been having a hard time repeating this error, so if you could check this fix that would be lovely.

This is my last Hacktoberfest PR! :)